### PR TITLE
Add CLI options for free models and Ollama integration

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,19 @@ load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "your_openrouter_api_key_here")
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
+# Ollama API settings
+OLLAMA_API_URL = os.getenv("OLLAMA_API_URL", "http://localhost:11434/api/generate")
+OLLAMA_MODELS = [
+    "llama3.2:latest",
+    "llama3.1:latest", 
+    "llama3:latest",
+    "mistral:latest",
+    "codellama:latest",
+    "gemma2:latest",
+    "qwen2.5:latest",
+    "phi3:latest",
+]
+
 # Firebase settings
 FIREBASE_CREDENTIALS_PATH = (
     "firebase_credentials.json"  # Path to your Firebase credentials file

--- a/src/openrouter.py
+++ b/src/openrouter.py
@@ -1,6 +1,6 @@
 """
-OpenRouter API client for the LLM Mafia Game Competition.
-This module handles all interactions with the OpenRouter API.
+Unified LLM API client for the LLM Mafia Game Competition.
+This module handles interactions with both OpenRouter and Ollama APIs.
 """
 
 import json
@@ -14,7 +14,82 @@ from logger import GameLogger
 model_logger = GameLogger(log_to_file=True)
 
 
-def get_llm_response(model_name, prompt):
+def is_ollama_model(model_name):
+    """
+    Check if a model name corresponds to an Ollama model.
+    
+    Args:
+        model_name (str): The model name to check.
+        
+    Returns:
+        bool: True if it's an Ollama model, False otherwise.
+    """
+    return model_name in config.OLLAMA_MODELS or model_name.startswith("ollama:")
+
+
+def get_ollama_response(model_name, prompt):
+    """
+    Get a response from an LLM model using Ollama API.
+
+    Args:
+        model_name (str): The name of the LLM model to use.
+        prompt (str): The prompt to send to the model.
+
+    Returns:
+        str: The response from the model.
+    """
+    # Get model-specific configuration if available
+    model_config = config.MODEL_CONFIGS.get(model_name, {})
+    
+    # Set timeout based on model config or defaults
+    timeout = model_config.get("timeout", config.API_TIMEOUT)
+
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    # Remove "ollama:" prefix if present
+    clean_model_name = model_name.replace("ollama:", "")
+
+    data = {
+        "model": clean_model_name,
+        "prompt": prompt,
+        "stream": False,
+        "options": {
+            "num_predict": config.MAX_OUTPUT_TOKENS,
+        }
+    }
+
+    try:
+        response = requests.post(
+            config.OLLAMA_API_URL,
+            headers=headers,
+            data=json.dumps(data),
+            timeout=timeout,
+        )
+        response.raise_for_status()
+
+        result = response.json()
+        return result["response"]
+
+    except Exception as e:
+        # Initialize response_text to handle cases where response is not defined
+        response_text = "No response received"
+
+        # Only try to access response.text if response is defined
+        try:
+            if "response" in locals():
+                response_text = response.text
+        except:
+            pass
+
+        print(
+            f"Error getting response from Ollama model {model_name}: error: {e}, response: {response_text}"
+        )
+        return "ERROR: Could not get response from Ollama"
+
+
+def get_openrouter_response(model_name, prompt):
     """
     Get a response from an LLM model using OpenRouter API.
 
@@ -66,6 +141,23 @@ def get_llm_response(model_name, prompt):
             pass
 
         print(
-            f"Error getting response from {model_name}: error: {e}, response: {response_text}"
+            f"Error getting response from OpenRouter model {model_name}: error: {e}, response: {response_text}"
         )
-        return "ERROR: Could not get response"
+        return "ERROR: Could not get response from OpenRouter"
+
+
+def get_llm_response(model_name, prompt):
+    """
+    Get a response from an LLM model using the appropriate API (OpenRouter or Ollama).
+
+    Args:
+        model_name (str): The name of the LLM model to use.
+        prompt (str): The prompt to send to the model.
+
+    Returns:
+        str: The response from the model.
+    """
+    if is_ollama_model(model_name):
+        return get_ollama_response(model_name, prompt)
+    else:
+        return get_openrouter_response(model_name, prompt)


### PR DESCRIPTION
- Add --free-models flag to use only free OpenRouter models
- Add --ollama flag to use Ollama models for local inference
- Add --num-games, --parallel, and --max-workers CLI options
- Integrate Ollama API support into openrouter.py as unified client
- Add OLLAMA_MODELS and OLLAMA_API_URL configuration options
- Support automatic API routing based on model names

Fixes #4